### PR TITLE
Copy to and from support

### DIFF
--- a/carto_cli/carto/carto_user.py
+++ b/carto_cli/carto/carto_user.py
@@ -133,3 +133,15 @@ class CARTOUser(object):
             (FORMAT CSV, DELIMITER '{delimiter}', HEADER true, QUOTE '"')"""
 
         return self.copy_client.copyfrom_file_path(query, path)
+
+
+    def copy_to(self, query, output, delimiter=','):
+        try:
+            self.copy_client
+        except AttributeError:
+            self.initialize()
+
+        copy_query = f"""COPY ({query}) TO stdout WITH
+        (FORMAT CSV, DELIMITER '{delimiter}', HEADER true, QUOTE '"')"""
+
+        return self.copy_client.copyto_file_path(copy_query, output)

--- a/carto_cli/carto/carto_user.py
+++ b/carto_cli/carto/carto_user.py
@@ -122,16 +122,15 @@ class CARTOUser(object):
         except AttributeError:
             self.initialize()
 
-        with open(path) as myfile:
-            headers = next(myfile).strip()
-
         if tablename is None:
             tablename = Path(path).stem
 
         if query is None:
-            query = f"""COPY {tablename} ({headers}) FROM stdin
-            (FORMAT CSV, DELIMITER '{delimiter}', HEADER true, QUOTE '"')"""
-
+            with open(path, 'rb') as myfile:
+                headers = next(myfile).strip().decode('utf8')
+                query = f"""COPY {tablename} ({headers}) FROM stdin
+                (FORMAT CSV, DELIMITER '{delimiter}', HEADER false, QUOTE '"')"""
+                return self.copy_client.copyfrom_file_object(query, myfile)
         return self.copy_client.copyfrom_file_path(query, path)
 
 

--- a/carto_cli/carto_dataset.py
+++ b/carto_cli/carto_dataset.py
@@ -49,7 +49,7 @@ cli.add_command(dataset.rename)
 cli.add_command(dataset.edit)
 cli.add_command(dataset.merge)
 cli.add_command(dataset.cartodbfy)
-
+cli.add_command(dataset.copy_from)
 
 if __name__ == '__main__':
     cli(obj={})

--- a/carto_cli/carto_dataset.py
+++ b/carto_cli/carto_dataset.py
@@ -50,6 +50,7 @@ cli.add_command(dataset.edit)
 cli.add_command(dataset.merge)
 cli.add_command(dataset.cartodbfy)
 cli.add_command(dataset.copy_from)
+cli.add_command(dataset.copy_to)
 
 if __name__ == '__main__':
     cli(obj={})

--- a/carto_cli/commands/dataset/dataset.py
+++ b/carto_cli/commands/dataset/dataset.py
@@ -445,15 +445,14 @@ def upload(ctx, sync, path):
     else:
         ctx.fail("The resource provided is not a valid URL or an existing file")
 
-@click.command(help="Copy a new dataset from a file on your computer")
+@click.command(help="Copy data from a file on your computer")
 @click.help_option('-h', '--help')
 @click.option('-t', '--tablename', help="Table to copy to", required=False)
 @click.option('-d', '--delimiter', help="csv delimiter. Default comma",default=",")
 @click.argument('path', callback=check_piped_arg, required=True)
 @click.argument('query', required=False)
-
 @click.pass_context
-def copy_from(ctx, path, query=None, tablename=None, delimiter=',',):
+def copy_from(ctx, path, query=None, tablename=None, delimiter=','):
     carto_obj = ctx.obj['carto']
 
     if os.path.exists(path):
@@ -461,6 +460,29 @@ def copy_from(ctx, path, query=None, tablename=None, delimiter=',',):
         click.echo("Local resource uploaded!")
     else:
         ctx.fail("The resource provided is not an existing file")
+
+
+@click.command(help="Copy data to a file on your computer")
+@click.help_option('-h', '--help')
+@click.argument('query', required=True)
+@click.argument('path')
+@click.option('-d', '--delimiter', help="csv delimiter. Default comma",default=",")
+@click.pass_context
+def copy_to(ctx, query, path, delimiter=','):
+    # ctx.invoke(run_sql,
+    #     format = 'csv',
+    #     output = output,
+    #     explain = False,
+    #     explain_analyze = False,
+    #     sql = query)
+    # click.echo("Query exported to {}".format(output.name))
+    carto_obj = ctx.obj['carto']
+    if os.path.exists(path):
+        ctx.fail("File exists!")
+    else:
+        task = carto_obj.copy_to(query, path, delimiter)
+        click.echo(f"Query exported to {path}")
+
 
 @click.command(help="Deletes a dataset from your account")
 @click.help_option('-h', '--help')

--- a/carto_cli/commands/dataset/dataset.py
+++ b/carto_cli/commands/dataset/dataset.py
@@ -467,8 +467,9 @@ def copy_from(ctx, path, query=None, tablename=None, delimiter=','):
 @click.argument('query', required=True)
 @click.argument('path')
 @click.option('-d', '--delimiter', help="csv delimiter. Default comma",default=",")
+@click.option('-w', '--do-no-overwrite',is_flag=True,help="Do no overwrite",default=True)
 @click.pass_context
-def copy_to(ctx, query, path, delimiter=','):
+def copy_to(ctx, query, path, delimiter=',', do_no_overwrite=True):
     # ctx.invoke(run_sql,
     #     format = 'csv',
     #     output = output,
@@ -477,11 +478,11 @@ def copy_to(ctx, query, path, delimiter=','):
     #     sql = query)
     # click.echo("Query exported to {}".format(output.name))
     carto_obj = ctx.obj['carto']
-    if os.path.exists(path):
+    if os.path.exists(path) and do_no_overwrite:
         ctx.fail("File exists!")
-    else:
-        task = carto_obj.copy_to(query, path, delimiter)
-        click.echo(f"Query exported to {path}")
+        return
+    task = carto_obj.copy_to(query, path, delimiter)
+    click.echo(f"Query exported to {path}")
 
 
 @click.command(help="Deletes a dataset from your account")

--- a/carto_cli/commands/dataset/dataset.py
+++ b/carto_cli/commands/dataset/dataset.py
@@ -445,6 +445,22 @@ def upload(ctx, sync, path):
     else:
         ctx.fail("The resource provided is not a valid URL or an existing file")
 
+@click.command(help="Copy a new dataset from a file on your computer")
+@click.help_option('-h', '--help')
+@click.option('-t', '--tablename', help="Table to copy to", required=False)
+@click.option('-d', '--delimiter', help="csv delimiter. Default comma",default=",")
+@click.argument('path', callback=check_piped_arg, required=True)
+@click.argument('query', required=False)
+
+@click.pass_context
+def copy_from(ctx, path, query=None, tablename=None, delimiter=',',):
+    carto_obj = ctx.obj['carto']
+
+    if os.path.exists(path):
+        task = carto_obj.copy_from(path, query, tablename, delimiter)
+        click.echo("Local resource uploaded!")
+    else:
+        ctx.fail("The resource provided is not an existing file")
 
 @click.command(help="Deletes a dataset from your account")
 @click.help_option('-h', '--help')


### PR DESCRIPTION
I used it to copy not cartodbfyied big tables.
It's quicker than import api.

Copy from: table must exist and have same columns as csv file.
Copy to: Allow export a query to csv

Documentation and examples needed. Sorry, but maybe someone can complete the PR.